### PR TITLE
Fixes and improvements for cmake of kite-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  add_definitions(-DDEBUG=1)
+endif()
 
 project(KITEx)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,18 @@ endif()
 
 project(KITEx)
 
-FILE(GLOB SRCFILES *.cpp)
-add_executable(KITEx ${SRCFILES})
+FILE(GLOB SRCFILES Src/*.cpp)
+add_executable(${PROJECT_NAME} ${SRCFILES})
 
 find_package(HDF5 COMPONENTS CXX C HL)
-set(HDF5_USE_STATIC_LIBRARIES ON)
-MESSAGE(STATUS "Hdf5 Library:  ${HDF5_CXX_HL_LIBRARIES}")
-MESSAGE(STATUS "Hdf5Hl Library:  ${HDF5_CXX_LIBRARIES}")
+if(${HDF5_FOUND})
+  include_directories(${HDF5_INCLUDE_DIR})
+  set(HDF5_USE_STATIC_LIBRARIES ON)
+  MESSAGE(STATUS "Hdf5 Library:  ${HDF5_CXX_HL_LIBRARIES}")
+  MESSAGE(STATUS "Hdf5Hl Library:  ${HDF5_CXX_LIBRARIES}")
+else()
+  MESSAGE(STATUS "Couldn't find HDF5")
+endif()
 MESSAGE(STATUS "Compiler:  ${CMAKE_CXX_COMPILER}")
 include_directories(~/include/)
 
@@ -31,16 +36,17 @@ else()
 endif()
 
 
+set (CORRECT_CODING_FLAGS "-Wall -Wextra -Wpedantic")
 find_package(OpenMP)
 MESSAGE(STATUS "OPENMP:  ${OPENMP_FOUND}")      
 if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "-Wall -Wextra -O3 ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_C_FLAGS "${CORRECT_CODING_FLAGS} ${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CORRECT_CODING_FLAGS} -Wall -Wextra -O3 ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CORRECT_CODING_FLAGS} ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_C_FLAGS}")
   else()
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+    set(CMAKE_CXX_FLAGS "${CORRECT_CODING_FLAGS} -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CORRECT_CODING_FLAGS} -g")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CORRECT_CODING_FLAGS} -O3")
 endif()
 
 
@@ -55,8 +61,6 @@ add_definitions(-DCOMPILE_WAVEPACKET=${compile_wp})
 
 
 include_directories(${Src})
-target_link_libraries(KITEx ${HDF5_CXX_LIBRARIES} )
+target_link_libraries(${PROJECT_NAME} ${HDF5_CXX_LIBRARIES} )
 
-
-
-
+install (TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,6 +7,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  add_definitions(-DDEBUG=1)
+endif()
 
 project(KITE-tools)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,9 +12,14 @@ project(KITE-tools)
 
 FILE(GLOB SRCFILES src/*.cpp)
 FILE(GLOB SRCFILES2 src/cond_2order/*.cpp)
-add_executable(KITE-tools ${SRCFILES} ${SRCFILES2})
+add_executable(${PROJECT_NAME} ${SRCFILES} ${SRCFILES2})
 
 find_package(HDF5 COMPONENTS CXX C HL)
+if(${HDF5_FOUND})
+  include_directories(${HDF5_INCLUDE_DIR})
+else()
+  MESSAGE(FATAL_ERROR  "Couldn't find hdf5")
+endif()
 set(HDF5_USE_STATIC_LIBRARIES ON)
 MESSAGE(STATUS "Hdf5 Library:  ${HDF5_CXX_HL_LIBRARIES}")
 MESSAGE(STATUS "Hdf5Hl Library:  ${HDF5_CXX_LIBRARIES}")
@@ -35,8 +40,9 @@ endif()
 find_package(OpenMP)
 MESSAGE(STATUS "OPENMP:  ${OPENMP_FOUND}")      
 if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "-g -O3 ${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "-g -O3 ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CORRECT_CODING_FLAGS "-Wall -Wextra -Wpedantic")
+    set (CMAKE_C_FLAGS "${CORRECT_CODING_FLAGS} -g -O3 ${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CORRECT_CODING_FLAGS} -g -O3 ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_C_FLAGS}")
   else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g")
@@ -45,8 +51,6 @@ endif()
 
 
 include_directories(${Src})
-target_link_libraries(KITE-tools ${HDF5_CXX_LIBRARIES} )
+target_link_libraries(${PROJECT_NAME} ${HDF5_CXX_LIBRARIES} )
 
-
-
-
+install (TARGETS ${PROJECT_NAME} DESTINATION bin)


### PR DESCRIPTION
This new cmake has successfully been tested on a Ubuntu 18.04. The changes:
- Fixes hardcoded KITE-tools
- Includes HDF5 headers
- Shows all possible unclean and dangerous code at bulid time
- Ads the install make-target (but it shouldn't be used while developing)

The cmake of KITEx has not been changed (yet)

Run cmake with a empty CORRECT_CODING_FLAGS if you don't want to see warnings.
Do not change it in the file, showing build-time warnings should be the default !