### PR TITLE
Cleanup kite-tools, better buildenv image

### DIFF
--- a/Dockerfile.buildenv
+++ b/Dockerfile.buildenv
@@ -10,6 +10,7 @@ RUN apt-get -y install valgrind gdb strace
 RUN apt-get -y install libhdf5-dev libeigen3-dev
 
 RUN groupadd -g $GID -o $UNAME && useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+RUN chown $UNAME /usr/local/bin
 
 USER $UNAME
 RUN mkdir /home/${UNAME}/kite

--- a/tools/src/arpes.cpp
+++ b/tools/src/arpes.cpp
@@ -366,7 +366,7 @@ void arpes<U, DIM>::calculate(){
   if(calculate_full_arpes){
 
     Eigen::Matrix<double, -1, -1> incidents = Eigen::Matrix<double, -1, -1>::Zero(DIM, NumVectors);
-    for(int ii = 0; ii < NumVectors; ii++){
+    for(unsigned int ii = 0; ii < NumVectors; ii++){
       incidents.col(ii) = incident_vector;
     }
 
@@ -374,7 +374,7 @@ void arpes<U, DIM>::calculate(){
     modulation = incident_vector.matrix().transpose()*(incidents + arpes_k_vectors.matrix())/incident_vector.matrix().norm();
 
 
-    for(int ii = 0; ii < NumVectors; ii++){
+    for(unsigned int ii = 0; ii < NumVectors; ii++){
       ARPES.col(ii) *= modulation(ii)*modulation(ii);
     }
   }

--- a/tools/src/cond_2order/Gamma1.cpp
+++ b/tools/src/cond_2order/Gamma1.cpp
@@ -37,7 +37,7 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma1shg
   int thread_num;
   int local_NumMoments;
   omp_set_num_threads(systemInfo.NumThreads);
-#pragma omp parallel shared(N_threads, cond) firstprivate(thread_num, DeltaMatrix)
+#pragma omp parallel shared(N_threads, cond) firstprivate(DeltaMatrix) private(thread_num)
 {
 #pragma omp master
 {

--- a/tools/src/cond_2order/Gamma1photo.cpp
+++ b/tools/src/cond_2order/Gamma1photo.cpp
@@ -42,7 +42,7 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma1con
   int local_NumMoments;
 
   omp_set_num_threads(systemInfo.NumThreads);
-#pragma omp parallel shared(N_threads, cond) firstprivate(thread_num, DeltaMatrix)
+#pragma omp parallel shared(N_threads, cond) firstprivate(DeltaMatrix) private(thread_num)
 {
 #pragma omp master
 {

--- a/tools/src/cond_2order/Gamma2.cpp
+++ b/tools/src/cond_2order/Gamma2.cpp
@@ -38,7 +38,7 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma2shg
   int thread_num;
   int local_NumMoments;
   omp_set_num_threads(systemInfo.NumThreads);
-#pragma omp parallel shared(N_threads, cond) firstprivate(thread_num, DeltaMatrix)
+#pragma omp parallel shared(N_threads, cond) firstprivate(DeltaMatrix) private(thread_num)
 {
 #pragma omp master
 {
@@ -72,11 +72,21 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma2shg
     local_cond = Eigen::Matrix<std::complex<U>, -1, -1>::Zero(N_energies, N_omegas);
     
     // Loop over the frequencies
-    //U w1, w2;
-    U w1, w2;
+/*
+ * Although frequencies2(w,0) was used to set w1 this value is never being used again.
+ * So i removed w1 from the code. To make sure that the program works exactly the same
+ * I still run frequencies2(w,0). This is needed because this function might do some
+ * things that influence other data, generate output, ...
+ *
+ * I assume that not using w1 was an oversight. If this is true I suggest uncommenting the
+ * code again and actually using it.
+ *
+ * -- Nikolas Garofil
+ */
+    U /*w1,*/ w2;
     std::complex<U> GammaEp, GammaEn, GammaE;
     for(int w = 0; w < N_omegas; w++){
-      w1 = frequencies2(w,0);
+      /*w1 = */frequencies2(w,0);
       w2 = frequencies2(w,1);
 
       for(int e = 0; e < N_energies; e++){

--- a/tools/src/cond_2order/Gamma2photo.cpp
+++ b/tools/src/cond_2order/Gamma2photo.cpp
@@ -37,7 +37,7 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma2con
   int thread_num;
   int local_NumMoments;
   omp_set_num_threads(systemInfo.NumThreads);
-#pragma omp parallel shared(N_threads, cond) firstprivate(thread_num, DeltaMatrix)
+#pragma omp parallel shared(N_threads, cond) firstprivate(DeltaMatrix) private(thread_num)
 {
 #pragma omp master
 {

--- a/tools/src/cond_2order/Gamma3.cpp
+++ b/tools/src/cond_2order/Gamma3.cpp
@@ -32,7 +32,6 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma3shg
   // number of threads, thread number and number of moments alocated
   // to each thread. These have to be computed inside a threaded block
   int N_threads;
-  int thread_num;
   int local_NumMoments;
 
   // Functions that are going to be used by the contractor
@@ -143,7 +142,6 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma3shg
   // number of threads, thread number and number of moments alocated
   // to each thread. These have to be computed inside a threaded block
   int N_threads;
-  int thread_num;
   int local_NumMoments;
 
   // Functions that are going to be used by the contractor
@@ -256,7 +254,6 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma3shg
   // number of threads, thread number and number of moments alocated
   // to each thread. These have to be computed inside a threaded block
   int N_threads;
-  int thread_num;
   int local_NumMoments;
 
   // Functions that are going to be used by the contractor

--- a/tools/src/cond_2order/Gamma3photo.cpp
+++ b/tools/src/cond_2order/Gamma3photo.cpp
@@ -154,7 +154,6 @@ Eigen::Matrix<std::complex<U>, -1, -1> conductivity_nonlinear<U, DIM>::Gamma3Con
   // number of threads, thread number and number of moments alocated
   // to each thread. These have to be computed inside a threaded block
   int N_threads;
-  int thread_num;
   int local_NumMoments;
 
   // Functions that are going to be used by the contractor

--- a/tools/src/cond_2order/conductivity_2order.cpp
+++ b/tools/src/cond_2order/conductivity_2order.cpp
@@ -155,7 +155,6 @@ conductivity_nonlinear<T, DIM>::conductivity_nonlinear(system_info<T, DIM>& info
     // KPM parameters
     NumPoints = -1;
     special = 0;
-    dirString; 
 
   std::string name = info.filename;                           // name of the hdf5 file
   file = H5::H5File(name.c_str(), H5F_ACC_RDONLY);
@@ -347,11 +346,22 @@ void conductivity_nonlinear<U, DIM>::calculate_photo(){
   }
 
   U freq;
-  U w1, w2;
+/*
+ * Although frequencies2() was used to set w1 and w2 these values are never being used again.
+ * So i removed w1 and w2 from the code. To make sure that the program works exactly the same
+ * I still run the frequencies2() functions. This is needed because this function might do some
+ * things that influence other data, generate output, ...
+ *
+ * I assume that not using w1 and w2 was an oversight. If this is true I suggest uncommenting the
+ * code again and actually using it.
+ *
+ * -- Nikolas Garofil
+ */
+  //U w1, w2;
   for(int w = 0; w < N_omegas; w++){
     freq = frequencies(w);  
-    w1 = frequencies2(w,0);
-    w2 = frequencies2(w,1);
+    /*w1 =*/ frequencies2(w,0);
+    /*w2 =*/ frequencies2(w,1);
 
     // Energy integration
     cond0(w) = integrate(energies, Eigen::Matrix<std::complex<U>,-1,1>(omega_energies0.col(w)));

--- a/tools/src/cond_dc/conductivity_dc.cpp
+++ b/tools/src/cond_dc/conductivity_dc.cpp
@@ -375,7 +375,7 @@ void conductivity_dc<U, DIM>::calculate2(){
 
   // save to a file
   save_to_file(condDC);
-};
+}
 
 
 // Instantiations

--- a/tools/src/parse_input.cpp
+++ b/tools/src/parse_input.cpp
@@ -223,12 +223,12 @@ shell_input::shell_input(int argc, char *argv[]){
 
     // Run the input through each of these functions to find the relevant 
     // parameters to each of them
-    parse_CondDC(argc, argv);
-    parse_DOS(argc, argv);
-    parse_lDOS(argc, argv);
+    parse_CondDC(argv);
+    parse_DOS(argv);
+    parse_lDOS(argv);
     parse_ARPES(argc, argv);
-    parse_CondOpt(argc, argv);
-    parse_CondOpt2(argc, argv);
+    parse_CondOpt(argv);
+    parse_CondOpt2(argv);
 
     // Process the exclusive flag. If there are no exclusive functions, 
     // all will be calculated. If there's only one, that's the only one
@@ -277,7 +277,7 @@ int shell_input::get_num_exclusives(){
     return N_exclusives;
 }
 
-void shell_input::parse_CondDC(int argc, char *argv[]){
+void shell_input::parse_CondDC(char *argv[]){
     // This function looks at the command-line input pertaining to CondDC and
     // finds the parameters for the temperature "T", number of energy points "E", 
     // scattering parameter "S" and Fermi energy min, max and num "F"
@@ -345,7 +345,7 @@ void shell_input::parse_CondDC(int argc, char *argv[]){
     }
 }
 
-void shell_input::parse_CondOpt(int argc, char* argv[]){
+void shell_input::parse_CondOpt(char* argv[]){
     // This function looks at the command-line input pertaining to CondOpt and
     // finds the parameters for the temperature "t", number of energy points "E", 
     // scattering parameter "S", Fermi energy "F" and min_freq, max_freq, num_freqs "O"
@@ -407,7 +407,7 @@ void shell_input::parse_CondOpt(int argc, char* argv[]){
     }
 }
 
-void shell_input::parse_CondOpt2(int argc, char* argv[]){
+void shell_input::parse_CondOpt2(char* argv[]){
     // This function looks at the command-line input pertaining to CondOpt2 and
     // finds the parameters for the temperature "t", number of energy points "E", 
     // scattering parameter "S", Fermi energy "F" and min_freq, max_freq, num_freqs "O"
@@ -466,7 +466,7 @@ void shell_input::parse_CondOpt2(int argc, char* argv[]){
     }
 }
 
-void shell_input::parse_DOS(int argc, char* argv[]){
+void shell_input::parse_DOS(char* argv[]){
     // This function looks at the command-line input pertaining to CondDC and
     // finds the parameters for the temperature "t", number of energy points "E", 
     // scattering parameter "S" and Fermi energy min, max and num "F"
@@ -514,7 +514,7 @@ void shell_input::parse_DOS(int argc, char* argv[]){
 }
 
 
-void shell_input::parse_lDOS(int argc, char* argv[]){
+void shell_input::parse_lDOS(char* argv[]){
     // This function looks at the command-line input pertaining to CondDC and
     // finds the parameters for the temperature "t", number of energy points "E", 
     // scattering parameter "S" and Fermi energy min, max and num "F"

--- a/tools/src/parse_input.hpp
+++ b/tools/src/parse_input.hpp
@@ -102,11 +102,11 @@ class shell_input{
         void printlDOS();
         void printARPES();
 
-        void parse_CondDC(int argc, char *argv[]);
-        void parse_CondOpt(int argc, char *argv[]);
-        void parse_CondOpt2(int argc, char *argv[]);
-        void parse_DOS(int argc, char *argv[]);
-        void parse_lDOS(int argc, char *argv[]);
+        void parse_CondDC(char *argv[]);
+        void parse_CondOpt(char *argv[]);
+        void parse_CondOpt2(char *argv[]);
+        void parse_DOS(char *argv[]);
+        void parse_lDOS(char *argv[]);
         void parse_ARPES(int argc, char *argv[]);
         int get_num_exclusives();
 


### PR DESCRIPTION
Now that the kitex cleanups are accepted: here are the kite-tools cleanups.

The dockerimage use to created a container that can be used as common buildenv didn't support writing the binaries to the /usr/local/bin of the container. Now it does.
(Contact me for more info on how to use the kite dockerimages)